### PR TITLE
Load cursor from existing file

### DIFF
--- a/src/main/java/io/github/stanio/io/DataFormatException.java
+++ b/src/main/java/io/github/stanio/io/DataFormatException.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Stanio <stanio AT yahoo DOT com>
+ * SPDX-License-Identifier: 0BSD
+ */
+package io.github.stanio.io;
+
+import java.io.IOException;
+
+/**
+ * Signals an error parsing the data vs. error reading the data (device error).
+ * Generic yet more specific {@code IOException} type for ad hoc use in code
+ * that doesn't define its own parsing error exception (hierarchy), yet.
+ */
+public class DataFormatException extends IOException {
+
+    private static final long serialVersionUID = -8949084403782324838L;
+
+    public DataFormatException(String message) {
+        super(message);
+    }
+
+    public DataFormatException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/io/github/stanio/io/ReadableChannelBuffer.java
+++ b/src/main/java/io/github/stanio/io/ReadableChannelBuffer.java
@@ -1,0 +1,252 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Stanio <stanio AT yahoo DOT com>
+ * SPDX-License-Identifier: 0BSD
+ */
+package io.github.stanio.io;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.util.Objects;
+
+/**
+ * Encapsulates a source {@code ReadableByteChannel} and a {@code ByteBuffer} as
+ * means to read data from it.
+ */
+public class ReadableChannelBuffer {
+
+    private final ReadableByteChannel channel;
+    private ByteOrder byteOrder;
+    private ByteBuffer buffer;
+
+    public ReadableChannelBuffer(ReadableByteChannel channel) {
+        this(channel, 1024);
+    }
+
+    public ReadableChannelBuffer(ReadableByteChannel channel,
+                                 int initialCapacity) {
+        this.channel = Objects.requireNonNull(channel);
+        this.buffer = ByteBuffer.allocate(initialCapacity);
+        this.byteOrder = buffer.order();
+        buffer.limit(0); // initially empty
+    }
+
+    public ReadableChannelBuffer order(ByteOrder order) {
+        this.byteOrder = order;
+        buffer().order(order);
+        return this;
+    }
+
+    public ByteBuffer buffer() {
+        return buffer;
+    }
+
+    private ByteBuffer buffer(ByteBuffer buf) {
+        return this.buffer = buf;
+    }
+
+    public ReadableChannelBuffer advanceBuffer(int size) {
+        ByteBuffer buf = buffer();
+        buf.position(buf.position() + size);
+        return this;
+    }
+
+    public int available() {
+        return buffer().remaining();
+    }
+
+    // end-of-stream: read().available() == 0
+    public ReadableChannelBuffer read() throws IOException {
+        request(Math.max(1, buffer().capacity() - buffer().limit()));
+        return this;
+    }
+
+    // end-of-stream: request(1).remaining() == 0
+    public ByteBuffer request(int size) throws IOException {
+        ByteBuffer buf = buffer();
+        if (size <= buf.remaining())
+            return buf;
+
+        if (size > buf.capacity()) {
+            buf = buffer(ByteBuffer.allocate(size)
+                                   .order(byteOrder)
+                                   .put(buf));
+        } else {
+            buf.compact();
+        }
+        readChannel(buf);
+        return (ByteBuffer) buf.flip();
+    }
+
+    /*private*/ int readChannel(ByteBuffer dst) throws IOException {
+        if (!dst.hasRemaining())
+            return 0;
+
+        int bytesRead = channel.read(dst);
+        if (bytesRead == 0) {
+            throw new IOException("Zero bytes read (non-blocking channel?)");
+        }
+        return bytesRead;
+    }
+
+    public ByteBuffer ensure(int size) throws IOException {
+        ByteBuffer buf = request(size);
+        if (buf.remaining() < size) {
+            throw underfowException(size - buf.remaining());
+        }
+        return buf;
+    }
+
+    public ReadableByteChannel subChannel(long size) {
+        return new SubChannel(size);
+    }
+
+    public ByteBuffer copyNBytes(int n) throws IOException {
+        ByteBuffer result = ByteBuffer.allocate(n).order(byteOrder);
+        ByteBuffer buf = buffer();
+        if (buf.remaining() > n) {
+            int savedLimit = buf.limit();
+            buf.limit(buf.position() + n);
+            result.put(buf);
+            buf.limit(savedLimit);
+        } else {
+            result.put(buf);
+            readChannel(result);
+        }
+
+        if (result.remaining() > 0) {
+            throw underfowException(result.remaining());
+        }
+        return (ByteBuffer) result.flip();
+    }
+
+    public void skipNBytes(long n) throws IOException {
+        // REVISIT: Should this skip over only/directly from the channel?  If so,
+        // should it always reset/empty the buffer?  Otherwise reading after
+        // subsequent requests would first yield any previously remaining data.
+        // See also the SubChannel behavior – should it always start reading
+        // directly from the channel?  The current behavior makes more sense to me,
+        // until I change my mind.
+        long newPosition = buffer().position() + n;
+        if (newPosition > buffer().limit()) {
+            skipNChannelBytes(newPosition - buffer().limit());
+            buffer().limit(0); // empty
+        } else {
+            buffer().position((int) newPosition);
+        }
+    }
+
+    private void skipNChannelBytes(long n) throws IOException {
+        if (channel instanceof SeekableByteChannel) {
+            SeekableByteChannel sch = (SeekableByteChannel) channel;
+            long newPosition = sch.position() + n;
+            long underflow = newPosition - sch.size();
+            if (underflow > 0) {
+                sch.position(newPosition - underflow);
+                throw underfowException(underflow);
+            }
+            sch.position(newPosition);
+            return;
+        }
+
+        long remaining = n;
+        ByteBuffer tmp = buffer();
+        while (remaining > 0) {
+            int bytesToSkip = (int) Math.min(remaining, tmp.clear().capacity());
+            tmp.limit(bytesToSkip);
+            int bytesRead = readChannel(tmp);
+            if (bytesRead < 0)
+                throw underfowException(remaining);
+
+            remaining -= bytesRead;
+        }
+    }
+
+    private static EOFException underfowException(long size) {
+        return new EOFException(size + " more bytes required");
+    }
+
+
+    private class SubChannel implements ReadableByteChannel {
+
+        private final long limit;
+
+        private long totalRead;
+        private boolean forwardOnClose;
+        private boolean closed;
+
+        SubChannel(long limit) {
+            this.limit = limit;
+            this.forwardOnClose = true;
+        }
+
+        public long remaining() {
+            return limit - totalRead;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (closed) return;
+
+            if (forwardOnClose && remaining() > 0) {
+                try {
+                    skipNBytes(remaining());
+                } catch (EOFException e) {
+                    // Ignored.  Subsequent requires() will signal it,
+                    // otherwise keep it cool.
+                }
+            }
+            closed = true;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return !closed;
+        }
+
+        @Override
+        public int read(ByteBuffer dst) throws IOException {
+            if (!isOpen())
+                throw new ClosedChannelException();
+
+            if (remaining() <= 0)
+                return -1;
+
+            int dstLimit = dst.limit();
+            try {
+                if (dst.remaining() > remaining())
+                    dst.limit(dst.position() + (int) remaining());
+
+                int bytesRead = 0;
+                ByteBuffer head = buffer();
+                if (head.remaining() > dst.remaining()) {
+                    bytesRead = dst.remaining();
+                    dst.put(head.array(), head.arrayOffset() + head.position(), bytesRead);
+                    head.position(head.position() + bytesRead);
+                } else if (head.hasRemaining()) {
+                    bytesRead = head.remaining();
+                    dst.put(head);
+                }
+                if (dst.hasRemaining()) {
+                    int count = readChannel(dst);
+                    if (count < 0 && bytesRead == 0)
+                        return -1;
+
+                    bytesRead += count;
+                }
+                totalRead += bytesRead;
+                assert (totalRead <= limit);
+                return bytesRead;
+            } finally {
+                dst.limit(dstLimit);
+            }
+        }
+
+    } // class SubChannel
+
+
+}

--- a/src/main/java/io/github/stanio/windows/FourCC.java
+++ b/src/main/java/io/github/stanio/windows/FourCC.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Stanio <stanio AT yahoo DOT com>
+ * SPDX-License-Identifier: 0BSD
+ */
+package io.github.stanio.windows;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Locale;
+
+final class FourCC {
+
+    static final int SIZE = 4;
+
+    final byte[] bytes = new byte[SIZE];
+
+    boolean equalTo(byte[] another) {
+        return Arrays.equals(bytes, another);
+    }
+
+    FourCC from(ByteBuffer buf) {
+        buf.get(bytes);
+        // REVISIT: Possible validation types:
+        //  - Allow any bytes
+        //  - Allow 7-bit ASCII-only
+        //  - Allow printable ASCII-only, and space only for padding
+        return this;
+    }
+
+    String detailString() {
+        return String.format(Locale.ROOT, "0x%08X \"%s\"", bytes[3] |
+                (bytes[2] << 8) | (bytes[1] << 16) | (bytes[0] << 24), this);
+    }
+
+    @Override
+    public String toString() {
+        char[] str = new char[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            str[i] = (char) bytes[i];
+        }
+        return new String(str);
+    }
+}

--- a/src/main/java/io/github/stanio/windows/LittleEndianOutput.java
+++ b/src/main/java/io/github/stanio/windows/LittleEndianOutput.java
@@ -4,67 +4,159 @@
  */
 package io.github.stanio.windows;
 
-import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Objects;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 
 class LittleEndianOutput implements Closeable {
+    // REVISIT: Extract as more general BufferedWritableChannelOutput.
 
     public static final byte NUL = 0;
 
-    private final OutputStream out;
+    private static final ThreadLocal<ByteBuffer> localBuffer =
+            ThreadLocal.withInitial(() -> ByteBuffer.allocateDirect(1024)
+                                                    .order(ByteOrder.LITTLE_ENDIAN));
 
-    public LittleEndianOutput(OutputStream out) {
-        this.out = Objects.requireNonNull(out, "null output stream");
+    private final WritableByteChannel out;
+    private ByteBuffer outBuf;
+
+    public LittleEndianOutput(WritableByteChannel out) {
+        this.out = out;
+        this.outBuf = (ByteBuffer) localBuffer.get().clear();
+    }
+
+    private ByteBuffer ensureRemaining(int size) throws IOException {
+        if (outBuf.remaining() < size) {
+            flush();
+        }
+        return outBuf;
     }
 
     public void write(byte val) throws IOException {
-        out.write(val);
+        ensureRemaining(Byte.BYTES).put(val);
     }
 
-    public void write(byte[] buf) throws IOException {
-        out.write(buf);
+    public void write(byte[] src) throws IOException {
+        write(src, src.length);
     }
 
-    public void write(byte[] buf, int len) throws IOException {
-        out.write(buf, 0, len);
+    public void write(byte[] src, int len) throws IOException {
+        int remaining = len;
+        while (remaining > 0) {
+            if (!outBuf.hasRemaining())
+                flush();
+
+            int chunk = Math.min(remaining, outBuf.remaining());
+            outBuf.put(src, len - remaining, chunk);
+            remaining -= chunk;
+        }
+    }
+
+    public void write(ByteBuffer[] sources) throws IOException {
+        flush();
+
+        if (out instanceof GatheringByteChannel) {
+            long remaining = Stream.of(sources).mapToLong(ByteBuffer::remaining).sum();
+            while (remaining > 0) {
+                remaining -= ((GatheringByteChannel) out).write(sources);
+                Thread.yield();
+            }
+        } else {
+            for (ByteBuffer chunk : sources) {
+                while (chunk.hasRemaining()) {
+                    out.write(chunk);
+                    Thread.yield();
+                }
+            }
+        }
     }
 
     public void writeWord(short val) throws IOException {
-        out.write((val >> 0) & 0xFF);
-        out.write((val >> 8) & 0xFF);
+        ensureRemaining(Short.BYTES).putShort(val);
     }
 
     public void writeDWord(int val) throws IOException {
-        out.write((val >>  0) & 0xFF);
-        out.write((val >>  8) & 0xFF);
-        out.write((val >> 16) & 0xFF);
-        out.write((val >> 24) & 0xFF);
+        ensureRemaining(Integer.BYTES).putInt(val);
+    }
+
+    public void flush() throws IOException {
+        outBuf.flip();
+        while (outBuf.hasRemaining()) {
+            out.write(outBuf);
+            Thread.yield();
+        }
+        outBuf.clear();
     }
 
     @Override
     public void close() throws IOException {
+        flush();
         out.close();
     }
 
 
-    static class ByteArrayBuffer extends ByteArrayOutputStream {
+    static class BufferChunksOutputStream extends OutputStream {
 
-        ByteArrayBuffer() {
-            this(4 * 1024);
+        private final List<ByteBuffer> chunks = new ArrayList<>();
+        private ByteBuffer current;
+
+        BufferChunksOutputStream() {
+            this(1024);
         }
 
-        ByteArrayBuffer(int size) {
-            super(size);
+        BufferChunksOutputStream(int chunkSize) {
+            current = ByteBuffer.allocate(chunkSize)
+                                .order(ByteOrder.LITTLE_ENDIAN);
         }
 
-        byte[] array() {
+        public ByteBuffer[] chunks() {
+            return chunks.toArray(new ByteBuffer[chunks.size()]);
+        }
+
+        private ByteBuffer current() {
+            ByteBuffer buf = current;
+            if (!buf.hasRemaining()) {
+                chunks.add((ByteBuffer) buf.flip());
+                buf = ByteBuffer.allocate(buf.capacity())
+                                .order(buf.order());
+                current = buf;
+            }
             return buf;
         }
 
-    } // class ByteArrayBuffer
+        @Override
+        public void write(int b) {
+            current().put((byte) b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) {
+            int remaining = len;
+            while (remaining > 0) {
+                ByteBuffer chunk = current();
+                int count = Math.min(remaining, chunk.remaining());
+                chunk.put(b, off + (len - remaining), count);
+                remaining -= count;
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (current == null)
+                return;
+
+            chunks.add((ByteBuffer) current.flip());
+            current = null;
+        }
+
+    } // class BufferChunksOutputStream
 
 
 } // class LittleEndianOutput


### PR DESCRIPTION
Lays out the groundwork for #1.  Introduces `read(Path)` to `Cursor`, `AnimatedCursor`, and `XCursor`.  Loading existing files is supported as much as to allow the use case of updating cursors created previously by these classes.  Some features of the formats are not supported.  If encountered, e.g., by editing and saving files with other applications, a file may fail to be read or the unsupported data may be discarded (e.g., comment/info chunks).