### PR TITLE
Add option to update (vs.the default overwrite) existing cursor files

### DIFF
--- a/bibata/src/main/java/io/github/stanio/bibata/BitmapsRenderer.java
+++ b/bibata/src/main/java/io/github/stanio/bibata/BitmapsRenderer.java
@@ -35,6 +35,7 @@ import com.google.gson.JsonParseException;
 
 import io.github.stanio.cli.CommandLine;
 import io.github.stanio.cli.CommandLine.ArgumentException;
+
 import io.github.stanio.bibata.CursorNames.Animation;
 import io.github.stanio.bibata.options.ConfigFactory;
 import io.github.stanio.bibata.options.SizeScheme;
@@ -54,6 +55,7 @@ import io.github.stanio.bibata.svg.DropShadow;
  * @see  <a href="https://github.com/stanio/Bibata_Cursor">stanio/Bibata Cursor</a>
  */
 public class BitmapsRenderer {
+    // REVISIT: Rename to CursorGenerator, MouseGenerator, or just MouseGen for short.
 
     public enum OutputType { BITMAPS, WINDOWS_CURSORS, LINUX_CURSORS }
 
@@ -94,6 +96,11 @@ public class BitmapsRenderer {
                                        boolean allCursors,
                                        Collection<String> filter) {
         cursorNames.init(names, allCursors, filter);
+        return this;
+    }
+
+    public BitmapsRenderer updateExisting(boolean update) {
+        renderer.setUpdateExisting(update);
         return this;
     }
 
@@ -286,6 +293,7 @@ public class BitmapsRenderer {
                             cmdArgs.minStrokeWidth, cmdArgs.expandFillLimit)
                     .withResolutions(cmdArgs.resolutions())
                     .cursorNames(nameMapping, cmdArgs.allCursors, cmdArgs.cursorFilter)
+                    .updateExisting(cmdArgs.updateExisting)
                     .buildCursors(cmdArgs.outputType)
                     .render(renderConfig);
         } catch (IOException e) {
@@ -341,6 +349,8 @@ public class BitmapsRenderer {
         boolean defaultStrokeAlso;
         boolean allVariants;
 
+        boolean updateExisting;
+
         CommandArgs(String... args) {
             CommandLine cmd = CommandLine.ofUnixStyle()
                     .acceptOption("-s", sizes::addAll,
@@ -361,6 +371,7 @@ public class BitmapsRenderer {
                     .acceptOptionalArg("--linux-cursors", val ->
                             setOutputType(OutputType.LINUX_CURSORS, val, "x11-names"))
                     .acceptFlag("--all-cursors", () -> allCursors = true)
+                    .acceptFlag("--update-existing", () -> updateExisting = true)
                     .acceptOptionalArg("--pointer-shadow",
                             val -> pointerShadow = DropShadow.decode(val))
                     .acceptFlag("--no-shadow-also", () -> noShadowAlso = true)

--- a/bibata/src/main/java/io/github/stanio/bibata/BitmapsRenderer.java
+++ b/bibata/src/main/java/io/github/stanio/bibata/BitmapsRenderer.java
@@ -182,7 +182,7 @@ public class BitmapsRenderer {
             return;
 
         progress.push(cursorName);
-        renderer.loadFile(cursorName, svgFile, targetName);
+        renderer.setFile(cursorName, svgFile, targetName);
 
         for (ThemeConfig config : renderConfig) {
             // REVISIT: Test cursorName or animation.lowerName

--- a/bibata/src/main/java/io/github/stanio/bibata/CursorBuilder.java
+++ b/bibata/src/main/java/io/github/stanio/bibata/CursorBuilder.java
@@ -4,14 +4,22 @@
  */
 package io.github.stanio.bibata;
 
-import static io.github.stanio.bibata.CursorRenderer.staticFrame;
-
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.Objects;
 import java.util.Optional;
 
 import java.awt.Point;
 import java.awt.image.BufferedImage;
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+import javax.imageio.stream.MemoryCacheImageOutputStream;
 
 import io.github.stanio.windows.AnimatedCursor;
 import io.github.stanio.x11.XCursor;
@@ -20,38 +28,54 @@ import io.github.stanio.bibata.BitmapsRenderer.OutputType;
 import io.github.stanio.bibata.CursorNames.Animation;
 
 /**
- * Abstract cursor builder interface for use by the {@code BitmapsRendererBackend}
- * implementation.
+ * Abstract cursor builder interface for use by the {@code CursorRenderer}.
  *
- * @see  RendererBackend
+ * @see  CursorRenderer
  */
 abstract class CursorBuilder {
 
+    static final Integer staticFrame = 0;
+
+    protected final Path targetPath;
+
     protected final Optional<Animation> animation;
 
-    protected CursorBuilder(Animation animation) {
+    protected CursorBuilder(Path targetPath, Animation animation) {
+        this.targetPath = Objects.requireNonNull(targetPath);
         this.animation = Optional.ofNullable(animation);
     }
 
     static CursorBuilder newInstance(OutputType type,
+                                     Path targetPath,
                                      Animation animation,
-                                     float targetCanvasFactor) {
+                                     float targetCanvasFactor)
+            throws UncheckedIOException {
         switch (type) {
         case WINDOWS_CURSORS:
-            return new WindowsCursorBuilder(animation);
+            return new WindowsCursorBuilder(targetPath, animation);
 
         case LINUX_CURSORS:
-            return new LinuxCursorBuilder(animation, targetCanvasFactor);
+            return new LinuxCursorBuilder(targetPath, animation, targetCanvasFactor);
+
+        case BITMAPS:
+            return new BitmapOtputBuilder(targetPath, animation);
 
         default:
             throw new IllegalArgumentException("Unsupported output type: " + type);
         }
     }
 
-    abstract void addFrame(Integer frameNo, BufferedImage image, Point hotspot);
+    abstract void addFrame(Integer frameNo, BufferedImage image, Point hotspot)
+            throws UncheckedIOException;
 
-    abstract void writeTo(Path target) throws IOException;
+    abstract void build() throws IOException;
 
+    final Integer validFrameNo(Integer num) {
+        if (animation.isPresent() && num == null) {
+            throw new IllegalArgumentException("Frame number is required for animations");
+        }
+        return (num == null) ? staticFrame : num;
+    }
 
     /**
      * Builds Windows cursors.
@@ -63,23 +87,24 @@ abstract class CursorBuilder {
 
         private final AnimatedCursor frames;
 
-        WindowsCursorBuilder(Animation animation) {
-            super(animation);
+        WindowsCursorBuilder(Path targetPath, Animation animation) {
+            super(targetPath, animation);
             this.frames = new AnimatedCursor(animation == null ? 0 : animation.jiffies());
         }
 
         @Override
         void addFrame(Integer frameNo, BufferedImage image, Point hotspot) {
-            frames.prepareFrame(frameNo).addImage(image, hotspot);
+            frames.prepareFrame(validFrameNo(frameNo))
+                    .addImage(image, hotspot);
         }
 
         @Override
-        void writeTo(Path target) throws IOException {
+        void build() throws IOException {
             if (animation.isEmpty()) {
                 frames.prepareFrame(staticFrame)
-                        .write(target.resolveSibling(target.getFileName() + ".cur"));
+                        .write(targetPath.resolveSibling(targetPath.getFileName() + ".cur"));
             } else {
-                frames.write(target.resolveSibling(target.getFileName() + ".ani"));
+                frames.write(targetPath.resolveSibling(targetPath.getFileName() + ".ani"));
             }
         }
 
@@ -97,23 +122,70 @@ abstract class CursorBuilder {
 
         private final int frameDelay;
 
-        LinuxCursorBuilder(Animation animation, float targetCanvasSize) {
-            super(animation);
+        LinuxCursorBuilder(Path targetPath, Animation animation, float targetCanvasSize) {
+            super(targetPath, animation);
             this.frames = new XCursor(targetCanvasSize);
             this.frameDelay = (animation == null) ? 0 : animation.delayMillis();
         }
 
         @Override
         void addFrame(Integer frameNo, BufferedImage image, Point hotspot) {
-            frames.addFrame(frameNo, image, hotspot, frameDelay);
+            frames.addFrame(validFrameNo(frameNo), image, hotspot, frameDelay);
         }
 
         @Override
-        void writeTo(Path target) throws IOException {
-            frames.writeTo(target);
+        void build() throws IOException {
+            frames.writeTo(targetPath);
         }
 
     } // class LinuxCursorBuilder
+
+
+    private static class BitmapOtputBuilder extends CursorBuilder {
+
+        private static final ThreadLocal<ImageWriter> pngWriter = ThreadLocal.withInitial(() -> {
+            Iterator<ImageWriter> iter = ImageIO.getImageWritersByFormatName("png");
+            if (iter.hasNext()) {
+                return iter.next();
+            }
+            throw new IllegalStateException("PNG image writer not registered/available");
+        });
+
+        BitmapOtputBuilder(Path targetPath, Animation animation) throws UncheckedIOException {
+            super(targetPath, animation);
+            try {
+                Files.createDirectories(targetPath);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        void addFrame(Integer frameNo, BufferedImage image, Point hotspot) {
+            // REVISIT: Eliminate suffix when rendering just "source" dimension
+            String sizeSuffix = (image.getWidth() < 100 ? "-0" : "-") + image.getWidth();
+            String fileName = targetPath.getFileName() + sizeSuffix
+                    + animation.map(a -> "-" + validFrameNo(frameNo)).orElse("") + ".png";
+            Path pngFile = (animation == null || frameNo == null)
+                           ? targetPath.resolveSibling(fileName)
+                           : targetPath.resolve(fileName);
+            ImageWriter imageWriter = pngWriter.get();
+            try (OutputStream fileOut = Files.newOutputStream(pngFile);
+                    ImageOutputStream out = new MemoryCacheImageOutputStream(fileOut)) {
+                imageWriter.setOutput(out);
+                imageWriter.write(image);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            } finally {
+                //imageWriter.reset();
+                imageWriter.setOutput(null);
+            }
+        }
+
+        @Override
+        void build() {/* no-op */}
+
+    } // class BitmapOtputBuilder
 
 
 } // class CursorBuilder

--- a/bibata/src/main/java/io/github/stanio/bibata/CursorRenderer.java
+++ b/bibata/src/main/java/io/github/stanio/bibata/CursorRenderer.java
@@ -33,8 +33,6 @@ import io.github.stanio.bibata.svg.SVGTransformer;
  * @see  BitmapsRenderer
  */
 final class CursorRenderer {
-    // REVISIT: Rename to CursorCompiler, and rename BitmapsRenderer to
-    // CursorGenerator The current CursorCompiler (wincur) is no longer needed.
 
     protected OutputType outputType;
 
@@ -49,6 +47,7 @@ final class CursorRenderer {
     private String targetName;
 
     private Path outDir;
+    private boolean updateExisting;
 
     private Optional<Double> strokeWidth = Optional.empty();
     private Map<String, String> colorMap = Collections.emptyMap();
@@ -146,6 +145,10 @@ final class CursorRenderer {
         outputSet = false;
     }
 
+    public void setUpdateExisting(boolean update) {
+        this.updateExisting = update;
+    }
+
     public void setCanvasSize(SizeScheme sizeScheme) {
         this.canvasSizing = sizeScheme;
     }
@@ -229,7 +232,7 @@ final class CursorRenderer {
 
     private CursorBuilder newCursorBuilder() throws UncheckedIOException {
         return CursorBuilder.newInstance(outputType,
-                outDir.resolve(targetName),
+                outDir.resolve(targetName), updateExisting,
                 animation, 1 / (float) canvasSizing.nominalSize);
     }
 
@@ -270,9 +273,6 @@ final class CursorRenderer {
     }
 
     public void saveCurrent() throws IOException {
-        if (outputType == OutputType.BITMAPS)
-            return;
-
         // Static cursor or complete animation
         if (animation == null || frameNum == null) {
             currentFrames.build();


### PR DESCRIPTION
Introduces an `--update-existing` option.  The main use case is to add or update specific resolution(s) of previously rendered cursors.  Initially:

    mousegen -r 32,48,64

Then update and add w/o re-rendering all previous resolutions:

    mousegen -r 64,96 --update-existing

<details>
Stuff not currently supported:

-   Updating the frame rate or total number of frames of existing animations
-   Adding/updating a resolution to an extra frame of animation will result in that frame having just said resolution
-   It is not possible to remove specific existing resolutions
</details>

Builds on top of #2, closes #1.

---

Future consideration:

    --update-existing[=<mode>]

where `<mode>` could be:

-   `create` (create or overwrite, default when no option)
-   `create-new` (create new or fail, never overwrite)
-   `update` (update or create, default option value)
-   `update-only` (update or fail if not exist)
-   `update-existing` (update or skip, don't create new files)